### PR TITLE
change diff library to diff-match-patch

### DIFF
--- a/lib/records.js
+++ b/lib/records.js
@@ -1,4 +1,4 @@
-const jsdiff = require('diff');
+const DiffMatchPatch = require('diff-match-patch');
 const csvjson = require('csvjson');
 
 function typeOf(x) {
@@ -96,7 +96,24 @@ function diffRecords(as, bs) {
 	const data_a = flatMap(as, r => keys.map(k => r[k]));
 	const data_b = flatMap(bs, r => keys.map(k => r[k]));
 
-	const diffs = jsdiff.diffArrays(data_a, data_b);
+	const dmp = new DiffMatchPatch();dmp.Diff_EditCost = 0;
+	const meta = dmp.diff_linesToChars_(
+		data_a.map(s => !!s && !!s.replace ? s.replace(/\n/, "\uFEFF"): s).join("\n"),
+		data_b.map(s => !!s && !!s.replace ? s.replace(/\n/, "\uFEFF"): s).join("\n")
+	);
+	let diffs = dmp.diff_main(meta.chars1, meta.chars2, false);
+	dmp.diff_charsToLines_(diffs, meta.lineArray);
+	diffs = diffs.map(hunk => {
+		const value = hunk[1].replace(/\s+$/,"").split("\n")
+			.map(s => s.replace(/\uFEFF/, "\n"));
+		return {
+			added: hunk[0] === 1,
+			removed: hunk[0] === -1,
+			count: value.length,
+			value: value
+		}
+	});
+
 	const map_a = new Map();
 	const map_b = new Map();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,10 +870,10 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
-    "diff": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+    "diff-match-patch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
+      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
     },
     "docopt": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "csvjson": "^5.1.0",
-    "diff": "^4.0.1",
+    "diff-match-patch": "^1.0.4",
     "docopt": "^0.6.2",
     "knex": "^0.19.5",
     "sqlite3": "^4.0.7",

--- a/test/records.js
+++ b/test/records.js
@@ -56,7 +56,9 @@ describe('records module', () => {
 		});
 	});
 
-	describe('diff()', () => {
+	describe('diff()', function() {
+		this.timeout(2000);
+
 		it('no diffs for the same records', () => {
 			const as = [
 				{id: 'a', name: 'name #1', flag: true},
@@ -108,6 +110,21 @@ describe('records module', () => {
 			expect(actual).to.eql(expected);
 		});
 
+		function summerize(diff) {
+			const result = { a: {}, b: {} };
+			for (xs of diff.a.values()) {
+				xs.forEach(x => {
+					result.a[x] = (result.a[x] || 0) + 1;
+				});
+			}
+			for (xs of diff.b.values()) {
+				xs.forEach(x => {
+					result.b[x] = (result.b[x] || 0) + 1;
+				});
+			}
+			return result;
+		}
+
 		it('diffs for as which lack records', () => {
 			const as = [
 				{id: 'b', name: 'name #2', flag: false},
@@ -125,7 +142,7 @@ describe('records module', () => {
 				]),
 			};
 			const actual = diff(as, bs);
-			expect(actual).to.eql(expected);
+			expect(summerize(actual)).to.eql(summerize(expected));
 		});
 
 		it('diffs for bs which lack records', () => {
@@ -145,8 +162,26 @@ describe('records module', () => {
 				b: new Map(),
 			};
 			const actual = diff(as, bs);
-			expect(actual).to.eql(expected);
+			expect(summerize(actual)).to.eql(summerize(expected));
 		});
 
+		it('bench', () => {
+			const as = [];
+			const bs = [];
+			const rep = 1000;
+			for (let i = 0; i < rep; i++) {
+				as.push({
+					id: i,
+					name_a: `name-$i`
+				});
+				bs.push({
+					id: i,
+					name_b: `name-$i`
+				});
+			}
+			const actual = diff(as, bs);
+			const expectedSummary = { a: {name_b: rep}, b: {name_a: rep} };
+			expect(summerize(actual)).to.eql(expectedSummary);
+		});
 	});
 });


### PR DESCRIPTION
Diff のアルゴリズムを `diff-match-patch` (`google/diff-match-patch` を npm パッケージ化したもの) に差し替えました。
LCS の選択アルゴリズムの違いにより、行マッチの境界が従来のものとはずれてしまう (かつ、我々としてはやや改悪方向) 問題はありますが、パフォーマンスが大幅劣化するよりもやや不自然な diff が発生する方が良いと判断し、「diff の発生カラムが同じである 」(位置のズレは許容する) ようにテストを修正しました。