### PR TITLE
improve run-sql to support multiple sql execution

### DIFF
--- a/bin/run-sql.js
+++ b/bin/run-sql.js
@@ -23,10 +23,15 @@ Options:
 	try {
 		let args = docopt(usage);
 		const conn = new dblib.Connection();
-		const sql = await promisify(fs.readFile)(process.stdin.fd, 'utf8');
 		await conn.prepare(preparation(args['<preparation>']));
-		const records = await conn.query(sql);
-		console.log(formatter(args['--format'])(records, sql));
+		const sqls = (await promisify(fs.readFile)(process.stdin.fd, 'utf8'))
+			.split(";")
+			.map(sql => sql.trim())
+			.filter(sql => sql.length > 0);
+		for (let sql of sqls) {
+			const records = await conn.query(sql);
+			console.log(formatter(args['--format'])(records, sql));
+		}
 		process.exit(0);
 	} catch (e) {
 		console.error(e);


### PR DESCRIPTION
`run-sql.js` に標準入力で SQL を渡した場合、先頭の1文のみの実行結果しか返却されない (内部的に2文目以降が実行されるのかどうかは未検証)。この修正では、複数の SQL の実行に対応した。