### PR TITLE
Fix/normalize null

### DIFF
--- a/lib/records.js
+++ b/lib/records.js
@@ -68,7 +68,7 @@ function normalizeValue(x) {
 		case 'number':
 		case 'string':
 			if (String(x) === NULL_MARKER) {
-				return ['null', null];
+				return ['null', ''];
 			} else {
 				return ['string', String(x)];
 			}
@@ -77,7 +77,7 @@ function normalizeValue(x) {
 		case 'date':
 			return ['string', formatDate(x)];
 		default: // undefined, null, object, ...
-			return ['null', null];
+			return ['null', ''];
 	}
 }
 
@@ -201,6 +201,7 @@ function formatRecords(records, option) {
 	const sizes = keys.map(key => Math.max(minSize, eaw.getWidth(key)));
 	records.forEach(result => {
 		keys.forEach((key, i) => {
+      console.log(result[key]);
 			if (eaw.isNarrowCharacter(result[key])) {
 				sizes[i] = Math.max(sizes[i], eaw.getWidth(result[key]));
 			} else {

--- a/lib/records.js
+++ b/lib/records.js
@@ -201,7 +201,6 @@ function formatRecords(records, option) {
 	const sizes = keys.map(key => Math.max(minSize, eaw.getWidth(key)));
 	records.forEach(result => {
 		keys.forEach((key, i) => {
-      console.log(result[key]);
 			if (eaw.isNarrowCharacter(result[key])) {
 				sizes[i] = Math.max(sizes[i], eaw.getWidth(result[key]));
 			} else {


### PR DESCRIPTION
fix #13 
出力する際に想定される項目として「文字列」「boolean値」「NULL」の3通りがあるのですが、booleanは`valueOf`で数値に変換しているにも関わらず、NULLに対してそのまま処理を行っているのが原因かと思われます。
一応現在問題になっている3問に関してはこのパッチで全テストケースに正答出来るようになることを確認しました（他の問題ではまだ未確認です）