### PR TITLE
PostgreSQL起動のリトライ処理とPIDファイルの削除

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -68,18 +68,67 @@ class SQLiteCasette {
 class PostgreSQLCasette {
 	async newConnection(options) {
 		const exec = util.promisify(cp.exec);
-		const p = cp.spawn('docker-entrypoint.sh', ['postgres'], {
-			detached: true,
-		});
-		if (options.verbose) {
-			p.stdout.on('data', data => console.log(data.toString()));
-			p.stderr.on('data', data => console.error(data.toString()));
-		}
 		async function sleep(ms) {
 			return new Promise((res, rej) => {
 				setTimeout(() => res(), ms);
 			});
 		}
+
+		async function connect() {
+			return new Promise((_res, _rej) => {
+				let done = false;
+				const res = (...args) => {
+					if (!done) {
+						done = true;
+						_res(...args);
+					}
+				}
+				const rej = (...args) => {
+					if (!done) {
+						done = true;
+						_rej(...args);
+					}
+				}
+				sleep(10000).then(() => rej(new Error('Timeout database connection')));
+				const p = cp.spawn('docker-entrypoint.sh', ['postgres'], {
+					detached: true,
+				});
+				p.stdout.on('data', data => {
+					const message = data.toString();
+					if (options.verbose) {
+						console.log(message);
+					}
+					if (message.includes('database system is ready to accept connections')) {
+						res();
+					}
+				});
+				p.stderr.on('data', data => {
+					const message = data.toString();
+					if (options.verbose) {
+						console.error(message);
+					}
+					if (message.includes('database system is ready to accept connections')) {
+						res();
+					}
+				});
+			});
+		}
+
+		for (let retries = 5; retries > 0; retries--) {
+			if (fs.existsSync('/var/lib/postgresql/data/postmaster.pid')) {
+				fs.unlinkSync('/var/lib/postgresql/data/postmaster.pid');
+			}
+			try {
+				await connect();
+				break;
+			} catch (e) {
+				if (options.verbose) {
+					console.error(e);
+				}
+			}
+			await sleep(1000);
+		}
+
 		for (let retries = 20; retries > 0; retries--) {
 			try {
 				const conn = knex({
@@ -301,8 +350,8 @@ class Connection {
 		return await Promise.all(
 			zipWith(sqls, opt_args)
 				.map(sa => {
-					const explainSql = this._cassette.explainSql(sa[0]);
-					return this.query(explainSql, sa[1])
+						const explainSql = this._cassette.explainSql(sa[0]);
+						return this.query(explainSql, sa[1])
 							.then(records => ({sql: explainSql, records: records}))
 					}
 				)


### PR DESCRIPTION
`PostgreSQLCasette.newConnection` でPostgreSQLの起動がうまくいかないことがあり、その場合に `Failed to start PostgreSQL server` というエラーが表示されて実行できずに終わってしまうことがあったので、以下の仕組みを追加しました。

1. PostgreSQL起動部分のリトライ処理
    - 接続部分のリトライはしていましたが、起動部分はしていなかったので。
2. PID ファイル（ `/var/lib/postgresql/data/postmaster.pid` ）が存在していると起動に失敗するため起動前に削除

ただし、コードがかなり汚いので、問題提起と改善案のPRとして捉えていただければ。