### PR TITLE
Improve error message in `recordEqual` processing when column names are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ This software is released under the [MIT License](LICENSE).
 
 ## Release Note
 
+### Version 2.4.0
+
+* [Feat] Improve error message in `recordEqual` processing when column names are different.
+  
+### Version 2.3.1
+
+* [Bugfix] The `precheck` process in handling whitespace.
+
 ### Version 2.3.0
 
 * Bump sqlite3 to 5.0.11

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -46,6 +46,7 @@ module.exports = function(chai, util) {
 			val = filterColumns(val, column => !withoutColumn.has(column.toLowerCase()));
 		}
 
+		const columnsDiff = diffColumns(obj, val);
 		const diff = records.diff(obj, val);
 		const ok = diff.a.size === 0 && diff.b.size === 0;
 		let offset = ok ? 0 :
@@ -53,7 +54,13 @@ module.exports = function(chai, util) {
 
 		self.assert(
 			ok,
-			[
+			!!columnsDiff ? [
+				!!msg ? '' : _`Column names should equal to expected`,
+				_`Expected:`,
+				indent(records.format(columnsDiff.b, {diff: columnsDiff.diff.b, success: true})),
+				_`Actual:`,
+				indent(records.format(columnsDiff.a, {diff: columnsDiff.diff.a})),
+			].join('\n') : [
 				!!msg ? '' : _`Records should equal to expected`,
 				_`Expected:`,
 				indent(records.format(val, {limit: options?.limit, offset: offset, diff: diff.b, success: true})),
@@ -66,6 +73,25 @@ module.exports = function(chai, util) {
 				records.format(obj, offset)
 			].join('\n')
 		);
+	}
+
+	function diffColumns(expected, actual) {
+		if (expected.length === 0 || actual.length === 0) {
+			return null;
+		}
+		const eCols = Object.keys(expected[0]).map(k => ({ name: k }));
+		const aCols = Object.keys(actual[0]).map(k => ({ name: k }));
+		const diff = records.diff(eCols, aCols);
+		const ok = diff.a.size === 0 && diff.b.size === 0;
+		if (ok) {
+			return null;
+		} else {
+			return {
+				a: eCols,
+				b: aCols,
+				diff,
+			};
+		}
 	}
 
 	Assertion.addMethod('recordEqual', assertRecordEqual);

--- a/lib/i18n-buildin.js
+++ b/lib/i18n-buildin.js
@@ -6,6 +6,7 @@ module.exports = {
 		'row(s) inserted': '件が挿入されました',
 		'Records should equal to expected': 'レコードが期待値と一致しなければいけません',
 		'Records should not equal to followings': 'レコードが以下の値と一致してはいけません',
+		'Column names should equal to expected': 'カラム名が期待値と一致しなければいけません',
 		'Expected:': '期待値:',
 		'Actual:': '実際の値:',
 		'expected table full scan detected': 'テーブルフルスキャンが検出されなければならない',


### PR DESCRIPTION
https://givery.slack.com/archives/CHYCK63LG/p1674631547624309