### PR TITLE
Fix loadFromCSV

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -597,7 +597,7 @@ class Connection {
 		const rs = await Promise.all(
 			bulks.map(bulk => this._conn.insert(bulk).into(table))
 		);
-		return flatten(rs);
+		return rs.flatMap((r) => this._cassette.rows(r));
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "track-db-test-library",
-  "version": "2.6.0-rc3",
+  "version": "2.6.0-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "track-db-test-library",
-      "version": "2.6.0-rc3",
+      "version": "2.6.0-rc4",
       "license": "MIT",
       "dependencies": {
         "csvjson": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "track-db-test-library",
-  "version": "2.6.0-rc3",
+  "version": "2.6.0-rc4",
   "description": "Test utility for Track database challenges",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://givery.slack.com/archives/C04CT4DM279/p1722934088425599?thread_ts=1716879361.100549&cid=C04CT4DM279

で発覚。`connection.js` の中で、`Connection.prototype.query` を使わないのが `loadFromCSV` で、ここも SQL エンジンによって結果が変わるため、単なる `flatten` では SQLite 以外動作しない