### PR TITLE
no_fullscanの判定が効かない

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -262,7 +262,7 @@ module.exports = function(chai, util) {
 
 	function fullscan(records, tables, every) {
 		const re = new RegExp(
-			`^SCAN (${(tables || []).join('|') || '\\w+'})`
+			`^SCAN(?: TABLE)? (${(tables || []).join('|') || '\\w+'})`
 		);
 		return records[every ? 'every' : 'some'](record => re.test(record.detail));
 	}

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -262,7 +262,7 @@ module.exports = function(chai, util) {
 
 	function fullscan(records, tables, every) {
 		const re = new RegExp(
-			`^SCAN TABLE (${(tables || []).join('|') || '\\w+'})`
+			`^SCAN (${(tables || []).join('|') || '\\w+'})`
 		);
 		return records[every ? 'every' : 'some'](record => re.test(record.detail));
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "track-db-test-library",
-  "version": "2.6.0-rc6",
+  "version": "2.6.0-rc7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "track-db-test-library",
-      "version": "2.6.0-rc6",
+      "version": "2.6.0-rc7",
       "license": "MIT",
       "dependencies": {
         "csvjson": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "track-db-test-library",
-  "version": "2.6.0-rc6",
+  "version": "2.6.0-rc7",
   "description": "Test utility for Track database challenges",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# 概要
テストで `no_fullscan` を使用しましたが、フルスキャンが行われている際も、正解判定がされます。
https://github.com/givery-technology/track-db-test-library/blob/73500165c0d889a72ce79fddee856d7f3d725f16/doc/DEVELOPPING_SQL_CHALLENGES_ja.md?plain=1#L468